### PR TITLE
Fix timezone - removed IST text at the end

### DIFF
--- a/components/Clock.vue
+++ b/components/Clock.vue
@@ -24,7 +24,7 @@ export default {
       }
       h = h < 10 ? '0' + h : h
       m = m < 10 ? '0' + m : m
-      const formatedText = h + ':' + m + session + ' ' + 'IST'
+      const formatedText = h + ':' + m + session
       this.timer = formatedText
       setTimeout(this.clock, 1000)
     },


### PR DESCRIPTION
Closes #10 

The current solution works as it is. Tested by spoofing time zone using chrome dev tool bar.