### PR TITLE
Updated deprecated API endpoint from users/self to users?profile=true

### DIFF
--- a/adapters/auth/index.ts
+++ b/adapters/auth/index.ts
@@ -23,7 +23,7 @@ ErrorApiForbidden | ErrorApiUnauthorized | ErrorApiUnavailable | ErrorApiNotFoun
 export const getSelf = async (): Promise<GetSelfResponse> => {
   const config = getConfig();
   const response: GetSelfResponse = await axios
-    .get(`${config.RDS_API}/users/self/`, { withCredentials: true })
+    .get(`${config.RDS_API}/users?profile=true`, { withCredentials: true })
     .then(res => ({ data: transformSelfInfoFromApi(res.data) }))
     .catch((error) => {
       if (isAxiosError(error)) {


### PR DESCRIPTION
### Issue: 
Real-Dev-Squad/todo-action-item#255 repo#10

### Description: 
The PR removes the /users/self API endpoint and replaces it with /users?profile=true API

### Anything you would like to inform the reviewer about:

### Dev Tested:

- [Y] Yes
- [ ] No

### Put the Feature behind Feature Flag

- [ ] Yes
- [X] No

### Test Stats
![Screenshot 2024-12-10 030829](https://github.com/user-attachments/assets/86f7e292-47c2-4130-86bf-646e8ed44bf2)

### Images/video of the change:

### Follow-up Issues (if any):

> NOTE: After your PR is merged in main please verify its working on prod and raise a dev to main PR
